### PR TITLE
Improve styling and interactivity

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WeBuild Mockup</title>
+    <!-- Tailwind via CDN for quick styling -->
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,18 +26,27 @@ export default function App() {
 
   return (
     <WalletProvider>
-      <div className="p-4 font-sans">
-        <nav className="mb-4 space-x-2">
-          <button onClick={() => setPage('home')} className="underline">Home</button>
-          <button onClick={() => setPage('wallet')} className="underline">Wallet</button>
-          <button onClick={() => setPage('mint')} className="underline">Mint BRANCH</button>
-          <button onClick={() => setPage('redeem')} className="underline">Redeem BRANCH</button>
-          <button onClick={() => setPage('swap')} className="underline">Swap</button>
-          <button onClick={() => setPage('nft')} className="underline">NFTs</button>
-          <button onClick={() => setPage('ai')} className="underline">AI Access</button>
-          <button onClick={() => setPage('gov')} className="underline">Governance</button>
+      <div className="p-4 font-sans max-w-3xl mx-auto">
+        <nav className="mb-4 flex flex-wrap gap-2">
+          {Object.keys(pages).map(key => (
+            <button
+              key={key}
+              onClick={() => setPage(key)}
+              className={`px-2 py-1 rounded text-sm border ${page === key ? "bg-blue-600 text-white" : "bg-white text-blue-600"}`}
+            >
+              {key === 'mint'
+                ? 'Mint BRANCH'
+                : key === 'redeem'
+                ? 'Redeem BRANCH'
+                : key === 'gov'
+                ? 'Governance'
+                : key.charAt(0).toUpperCase() + key.slice(1)}
+            </button>
+          ))}
         </nav>
-        <Page />
+        <div className="bg-white p-4 rounded shadow">
+          <Page />
+        </div>
       </div>
     </WalletProvider>
   );

--- a/frontend/src/components/Home.jsx
+++ b/frontend/src/components/Home.jsx
@@ -4,7 +4,8 @@ export default function Home() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">WeBuild DAO Mockup</h1>
-      <p>Use the navigation above to explore the token lifecycle.</p>
+      <p className="mb-2">Use the navigation above to explore the token lifecycle.</p>
+      <p className="text-sm text-gray-600">This demo has no blockchain hooks but illustrates how SEED, BRANCH, FRUIT and ROOT interact.</p>
     </div>
   );
 }

--- a/frontend/src/components/MintBranch.jsx
+++ b/frontend/src/components/MintBranch.jsx
@@ -1,10 +1,17 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useEffect } from 'react';
 import { WalletContext } from '../context/WalletContext';
 
 export default function MintBranch() {
   const { balances, setBalances } = useContext(WalletContext);
   const [amount, setAmount] = useState('');
   const [timer, setTimer] = useState(0);
+
+  useEffect(() => {
+    if (timer > 0) {
+      const id = setInterval(() => setTimer(t => t - 1), 1000);
+      return () => clearInterval(id);
+    }
+  }, [timer]);
 
   const handleMint = () => {
     const seedRequired = (amount * 0.8);


### PR DESCRIPTION
## Summary
- add Tailwind via CDN in the frontend
- restyle the navigation bar and layout
- show more details on the home screen
- add a countdown timer when minting

## Testing
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e106d79fc8324aa89601a1a29fad9