### PR TITLE
Add persistent wallet and new token flows

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 import { WalletProvider } from './context/WalletContext';
 import Home from './components/Home';
 import Wallet from './components/Wallet';
+import EarnSeed from './components/EarnSeed';
 import MintBranch from './components/MintBranch';
 import RedeemBranch from './components/RedeemBranch';
+import AccrueRoot from './components/AccrueRoot';
 import AMMSwap from './components/AMMSwap';
 import NFTMint from './components/NFTMint';
 import AIAgentAccess from './components/AIAgentAccess';
@@ -12,8 +14,10 @@ import Governance from './components/Governance';
 const pages = {
   home: Home,
   wallet: Wallet,
+  earn: EarnSeed,
   mint: MintBranch,
   redeem: RedeemBranch,
+  accrue: AccrueRoot,
   swap: AMMSwap,
   nft: NFTMint,
   ai: AIAgentAccess,
@@ -38,6 +42,10 @@ export default function App() {
                 ? 'Mint BRANCH'
                 : key === 'redeem'
                 ? 'Redeem BRANCH'
+                : key === 'earn'
+                ? 'Earn SEED'
+                : key === 'accrue'
+                ? 'Accrue ROOT'
                 : key === 'gov'
                 ? 'Governance'
                 : key.charAt(0).toUpperCase() + key.slice(1)}

--- a/frontend/src/assets/nft-placeholder.svg
+++ b/frontend/src/assets/nft-placeholder.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+  <rect width="200" height="200" fill="#a3e635" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="36" fill="#000" font-family="sans-serif">NFT</text>
+</svg>

--- a/frontend/src/components/AccrueRoot.jsx
+++ b/frontend/src/components/AccrueRoot.jsx
@@ -1,0 +1,25 @@
+import React, { useContext } from 'react';
+import { WalletContext } from '../context/WalletContext';
+
+export default function AccrueRoot() {
+  const { balances, setBalances } = useContext(WalletContext);
+
+  const accrue = () => {
+    const reward = balances.fruit * 0.1;
+    if (reward > 0) {
+      setBalances({ ...balances, root: balances.root + reward });
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-2">Accrue ROOT</h2>
+      <p className="mb-2 text-sm text-gray-600">
+        Claim 0.1 ROOT for every FRUIT you hold.
+      </p>
+      <button onClick={accrue} className="bg-purple-600 text-white px-2 py-1">
+        Claim ROOT
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/EarnSeed.jsx
+++ b/frontend/src/components/EarnSeed.jsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { WalletContext } from '../context/WalletContext';
+
+export default function EarnSeed() {
+  const { balances, setBalances } = useContext(WalletContext);
+  const earn = () => {
+    setBalances({ ...balances, seed: balances.seed + 1000 });
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-2">Earn SEED</h2>
+      <button onClick={earn} className="bg-green-600 text-white px-2 py-1">
+        Earn 1,000 SEED
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/NFTMint.jsx
+++ b/frontend/src/components/NFTMint.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { WalletContext } from '../context/WalletContext';
+import nftImg from '../assets/nft-placeholder.svg';
 
 export default function NFTMint() {
   const { nfts, setNfts } = useContext(WalletContext);
@@ -11,6 +12,7 @@ export default function NFTMint() {
   return (
     <div>
       <h2 className="text-xl font-bold mb-2">NFT Minting (Mock)</h2>
+      <img src={nftImg} alt="NFT placeholder" className="w-32 h-32 mb-2" />
       <button onClick={() => mint('seed')} disabled={nfts.seed} className="bg-gray-500 text-white px-2 py-1 mr-2">
         {nfts.seed ? 'Seed NFT Minted' : 'Mint Seed NFT'}
       </button>

--- a/frontend/src/context/WalletContext.jsx
+++ b/frontend/src/context/WalletContext.jsx
@@ -1,20 +1,38 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
 
 export const WalletContext = createContext();
 
+const defaultBalances = {
+  seed: 10000,
+  branch: 0,
+  fruit: 0,
+  root: 0,
+};
+
+const defaultNfts = {
+  seed: false,
+  branch: false,
+  fruit: false,
+};
+
 export function WalletProvider({ children }) {
-  const [balances, setBalances] = useState({
-    seed: 10000,
-    branch: 0,
-    fruit: 0,
-    root: 0,
+  const [balances, setBalances] = useState(() => {
+    const saved = localStorage.getItem('balances');
+    return saved ? JSON.parse(saved) : defaultBalances;
   });
 
-  const [nfts, setNfts] = useState({
-    seed: false,
-    branch: false,
-    fruit: false,
+  const [nfts, setNfts] = useState(() => {
+    const saved = localStorage.getItem('nfts');
+    return saved ? JSON.parse(saved) : defaultNfts;
   });
+
+  useEffect(() => {
+    localStorage.setItem('balances', JSON.stringify(balances));
+  }, [balances]);
+
+  useEffect(() => {
+    localStorage.setItem('nfts', JSON.stringify(nfts));
+  }, [nfts]);
 
   return (
     <WalletContext.Provider value={{ balances, setBalances, nfts, setNfts }}>


### PR DESCRIPTION
## Summary
- store wallet balances and NFTs in localStorage so they're persistent
- add EarnSeed and AccrueRoot components
- update navigation to include new pages
- show placeholder NFT image

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*
- `npm install` in backend *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684e12c3fab88324a56e97928051953f